### PR TITLE
Don't blow away manpages.

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -29,5 +29,5 @@ make -j$CPU_COUNT
 make install
 
 pushd $PREFIX
-rm -rf lib/libpoppler*.la lib/libpoppler*.a share/gtk-doc share/man
+rm -rf lib/libpoppler*.la lib/libpoppler*.a share/gtk-doc
 popd

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   detect_binary_files_with_prefix: true
   skip: true  # [win or not py36]
 


### PR DESCRIPTION
As suggested by @ocefpaf. But this commit is mostly about triggering a rebuild — the first build failed since there was a problem setting up the poppler-data feedstock, which is needed at runtime.