### PR TITLE
Update 0.61.1

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,8 +1,8 @@
 #! /bin/bash
 
-# if [ $(uname) = Darwin ] ; then
-#     export LDFLAGS="$LDFLAGS -Wl,-rpath,$PREFIX/lib"
-# fi
+if [ $(uname) = Darwin ] ; then
+    export LDFLAGS="$LDFLAGS -Wl,-rpath,$PREFIX/lib"
+fi
 # export CPPFLAGS="$CPPFLAGS -I$PREFIX/include"
 # export LDFLAGS="$LDFLAGS -L$PREFIX/lib"
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,24 +1,30 @@
 #! /bin/bash
 
-if [ $(uname) = Darwin ] ; then
-    export LDFLAGS="$LDFLAGS -Wl,-rpath,$PREFIX/lib"
+set -e
+
+# The zlib check does not let you specify its install prefix so we have
+# to go global.
+export CFLAGS="${CFLAGS} -I${PREFIX}/include"
+export CPPFLAGS="${CPPFLAGS} -I${PREFIX}/include"
+export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
+if [[ ${HOST} =~ .*darwin.* ]] ; then
+    export LDFLAGS="${LDFLAGS} -Wl,-rpath,${PREFIX}/lib"
 fi
-# export CPPFLAGS="$CPPFLAGS -I$PREFIX/include"
-# export LDFLAGS="$LDFLAGS -L$PREFIX/lib"
 
 mkdir build && cd build
 
-cmake  -D CMAKE_BUILD_TYPE=Release \
-       -D CMAKE_INSTALL_PREFIX=$PREFIX \
-       -D CMAKE_INSTALL_LIBDIR:PATH=$PREFIX/lib \
-       -D TESTDATADIR=$PWD/testfiles \
-       -D ENABLE_XPDF_HEADERS=ON \
+cmake -G "$CMAKE_GENERATOR" \
+      -DCMAKE_PREFIX_PATH=$PREFIX \
+      -DCMAKE_INSTALL_PREFIX=$PREFIX \
+      -DENABLE_XPDF_HEADERS=True \
+      -DENABLE_LIBCURL=True \
+      -DENABLE_LIBOPENJPEG=openjpeg2 \
        $SRC_DIR
 
 make -j$CPU_COUNT
 # ctest  # no tests were found :-/
 make install -j$CPU_COUNT
 
-pushd $PREFIX
-rm -rf lib/libpoppler*.la lib/libpoppler*.a share/gtk-doc
+pushd ${PREFIX}
+  rm -rf lib/libpoppler*.la lib/libpoppler*.a share/gtk-doc
 popd

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -14,11 +14,12 @@ fi
 mkdir build && cd build
 
 cmake -G "$CMAKE_GENERATOR" \
-      -DCMAKE_PREFIX_PATH=$PREFIX \
-      -DCMAKE_INSTALL_PREFIX=$PREFIX \
-      -DENABLE_XPDF_HEADERS=True \
-      -DENABLE_LIBCURL=True \
-      -DENABLE_LIBOPENJPEG=openjpeg2 \
+      -D CMAKE_PREFIX_PATH=$PREFIX \
+      -D CMAKE_INSTALL_LIBDIR:PATH=$PREFIX/lib \
+      -D CMAKE_INSTALL_PREFIX=$PREFIX \
+      -D ENABLE_XPDF_HEADERS=True \
+      -D ENABLE_LIBCURL=True \
+      -D ENABLE_LIBOPENJPEG=openjpeg2 \
        $SRC_DIR
 
 make -j$CPU_COUNT

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 3
+  number: 4
   detect_binary_files_with_prefix: true
   skip: true  # [win or not py36]
 
@@ -29,7 +29,7 @@ requirements:
     - jpeg 9*
     - libpng >=1.6.22,<1.6.31
     - libtiff >=4.0.3,<4.0.8
-    - openjpeg 2.1.*
+    - openjpeg 2.3.*
     - zlib 1.2.11
   run:
     - poppler-data
@@ -40,7 +40,7 @@ requirements:
     - jpeg 9*
     - libpng >=1.6.22,<1.6.31
     - libtiff >=4.0.3,<4.0.8
-    - openjpeg 2.1.*
+    - openjpeg 2.3.*
     - zlib 1.2.11
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "poppler" %}
-{% set version = "0.52.0" %}
-{% set sha256 = "528b661738839f9a25f6e580fcd2d5db007e0a1948580c6489f0062798ca1992" %}
+{% set version = "0.61.1" %}
+{% set sha256 = "1266096343f5163c1a585124e9a6d44474e1345de5cdfe55dc7b47357bcfcda9" %}
 
 package:
   name: {{ name|lower }}
@@ -11,13 +11,14 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 4
+  number: 0
   detect_binary_files_with_prefix: true
   skip: true  # [win or not py36]
 
 requirements:
   build:
     - pkg-config  # [not win]
+    - cmake 3.9.6
     - toolchain
     - python
     - perl 5.22.2.1
@@ -60,3 +61,4 @@ about:
 extra:
   recipe-maintainers:
     - pkgw
+    - ocefpaf


### PR DESCRIPTION
@pkgw it seems that `cmake` is the only option now. However, I was [not able](https://travis-ci.org/ocefpaf/poppler-feedstock/builds/306301899 ) to get this to work with OS X.

Do you have any idea of what is going on?