### PR TITLE
build once for openjpeg 2.1.* for gdal 2.1.*

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   detect_binary_files_with_prefix: true
   skip: true  # [win or not py36]
 
@@ -30,7 +30,7 @@ requirements:
     - jpeg 9*
     - libpng >=1.6.22,<1.6.31
     - libtiff >=4.0.3,<4.0.8
-    - openjpeg 2.3.*
+    - openjpeg 2.1.*
     - zlib 1.2.11
   run:
     - poppler-data
@@ -41,7 +41,7 @@ requirements:
     - jpeg 9*
     - libpng >=1.6.22,<1.6.31
     - libtiff >=4.0.3,<4.0.8
-    - openjpeg 2.3.*
+    - openjpeg 2.1.*
     - zlib 1.2.11
 
 test:


### PR DESCRIPTION
@pkgw this is a 1-time thing b/c we still need a rebuild of `libgdal 2.1` with latest poppler, but that `libgdal` which only works with `openjpeg 2.1`. I'll revert this change once it is merge.

Closes #7 