### PR TITLE
turn ENABLE_RELOCATABLE to OFF on Windows

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,6 +1,10 @@
 mkdir build
 cd build
 
+:: Remove /GL from CXXFLAGS as this causes an error with the 
+:: cmake 'export all symbols' functionality
+set "CXXFLAGS= -MD"
+
 cmake -G "NMake Makefiles" ^
       -D CMAKE_BUILD_TYPE=Release ^
       -D CMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -9,6 +9,7 @@ cmake -G "NMake Makefiles" ^
       -D ENABLE_XPDF_HEADERS=True ^
       -D ENABLE_LIBCURL=True ^
       -D ENABLE_LIBOPENJPEG=openjpeg2 ^
+      -D ENABLE_RELOCATABLE=OFF ^
        %SRC_DIR%
 if errorlevel 1 exit 1	   
 

--- a/recipe/cmakelists.win.patch
+++ b/recipe/cmakelists.win.patch
@@ -1,5 +1,5 @@
 --- CMakeLists.txt.old	2019-01-22 09:40:00.632449800 +1000
-+++ CMakeLists.txt	2019-01-24 13:03:53.804403100 +1000
++++ CMakeLists.txt	2019-01-24 14:16:20.054376800 +1000
 @@ -201,11 +201,18 @@
  endif()
  set(WITH_OPENJPEG FALSE)
@@ -47,17 +47,18 @@
  
  if(EXTRA_WARN)
    set(CMAKE_C_FLAGS "-Wall ${CMAKE_C_FLAGS}")
-@@ -486,7 +482,8 @@
+@@ -485,8 +481,8 @@
+ 
  if(MSVC)
  add_definitions(-D_CRT_SECURE_NO_WARNINGS)
- set(CMAKE_CXX_FLAGS "/Zc:wchar_t- ${CMAKE_CXX_FLAGS}")
+-set(CMAKE_CXX_FLAGS "/Zc:wchar_t- ${CMAKE_CXX_FLAGS}")
 -add_library(poppler STATIC ${poppler_SRCS})
 +add_library(poppler SHARED ${poppler_SRCS})
 +set_target_properties(poppler PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS true)
  else()
  add_library(poppler ${poppler_SRCS})
  endif()
-@@ -676,6 +673,10 @@
+@@ -676,6 +672,10 @@
  
  set(PKG_CONFIG_VERSION_0_18 TRUE)
  if(PKG_CONFIG_EXECUTABLE)

--- a/recipe/cmakelists.win.patch
+++ b/recipe/cmakelists.win.patch
@@ -1,5 +1,5 @@
 --- CMakeLists.txt.old	2019-01-22 09:40:00.632449800 +1000
-+++ CMakeLists.txt	2019-01-22 10:13:22.505250600 +1000
++++ CMakeLists.txt	2019-01-24 13:03:53.804403100 +1000
 @@ -201,11 +201,18 @@
  endif()
  set(WITH_OPENJPEG FALSE)
@@ -47,7 +47,17 @@
  
  if(EXTRA_WARN)
    set(CMAKE_C_FLAGS "-Wall ${CMAKE_C_FLAGS}")
-@@ -676,6 +672,10 @@
+@@ -486,7 +482,8 @@
+ if(MSVC)
+ add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+ set(CMAKE_CXX_FLAGS "/Zc:wchar_t- ${CMAKE_CXX_FLAGS}")
+-add_library(poppler STATIC ${poppler_SRCS})
++add_library(poppler SHARED ${poppler_SRCS})
++set_target_properties(poppler PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS true)
+ else()
+ add_library(poppler ${poppler_SRCS})
+ endif()
+@@ -676,6 +673,10 @@
  
  set(PKG_CONFIG_VERSION_0_18 TRUE)
  if(PKG_CONFIG_EXECUTABLE)

--- a/recipe/cmakelists.win.patch
+++ b/recipe/cmakelists.win.patch
@@ -1,5 +1,5 @@
 --- CMakeLists.txt.old	2019-01-22 09:40:00.632449800 +1000
-+++ CMakeLists.txt	2019-01-24 14:16:20.054376800 +1000
++++ CMakeLists.txt	2019-01-24 15:31:14.179024700 +1000
 @@ -201,11 +201,18 @@
  endif()
  set(WITH_OPENJPEG FALSE)
@@ -47,18 +47,20 @@
  
  if(EXTRA_WARN)
    set(CMAKE_C_FLAGS "-Wall ${CMAKE_C_FLAGS}")
-@@ -485,8 +481,8 @@
+@@ -485,8 +481,10 @@
  
  if(MSVC)
  add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 -set(CMAKE_CXX_FLAGS "/Zc:wchar_t- ${CMAKE_CXX_FLAGS}")
 -add_library(poppler STATIC ${poppler_SRCS})
++# so we can determing if to import/export symbols
 +add_library(poppler SHARED ${poppler_SRCS})
++target_compile_definitions(poppler PRIVATE _COMPILING_POPPLER=1)
 +set_target_properties(poppler PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS true)
  else()
  add_library(poppler ${poppler_SRCS})
  endif()
-@@ -676,6 +672,10 @@
+@@ -676,6 +674,10 @@
  
  set(PKG_CONFIG_VERSION_0_18 TRUE)
  if(PKG_CONFIG_EXECUTABLE)

--- a/recipe/exportsymbols.patch
+++ b/recipe/exportsymbols.patch
@@ -1,0 +1,33 @@
+--- "poppler\\GlobalParams.h.old"	2019-01-24 15:16:18.390103900 +1000
++++ "poppler\\GlobalParams.h"	2019-01-24 15:16:32.992981800 +1000
+@@ -70,7 +70,13 @@
+ //------------------------------------------------------------------------
+ 
+ // The global parameters object.
+-extern GlobalParams *globalParams;
++#ifdef _COMPILING_POPPLER
++// cmake's WINDOWS_EXPORT_ALL_SYMBOLS doesn't extend to data unfortunately
++// so we must to this by hand
++extern __declspec(dllexport) GlobalParams *globalParams;
++#else
++extern __declspec(dllimport) GlobalParams *globalParams;
++#endif
+ 
+ //------------------------------------------------------------------------
+ 
+--- "poppler\\PDFDocEncoding.h.old"	2019-01-24 15:14:52.477686900 +1000
++++ "poppler\\PDFDocEncoding.h"	2019-01-24 15:15:01.447670700 +1000
+@@ -27,8 +27,11 @@
+ 
+ class GooString;
+ 
+-extern Unicode pdfDocEncoding[256];
+-
++#ifdef _COMPILING_POPPLER
++extern __declspec(dllexport) Unicode pdfDocEncoding[256];
++#else
++extern __declspec(dllimport) Unicode pdfDocEncoding[256];
++#endif
+ char* pdfDocEncodingToUTF16 (const GooString* orig, int* length);
+ 
+ #endif

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - poppler-page.win.patch  # [win]
 
 build:
-  number: 5
+  number: 6
   detect_binary_files_with_prefix: true
   skip: True  # [win and py27]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
     - cmakelists.win.patch  # [win]
     # see https://gitlab.freedesktop.org/poppler/poppler/commit/06106d930b18a34c18e32734b73c212b852161a5
     - poppler-page.win.patch  # [win]
+    - exportsymbols.patch  # [win]
 
 build:
   number: 6


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

xref: https://github.com/conda-forge/gdal-feedstock/pull/258.

By default with MSVC this option is turned on and it means that the code looks relative to the DLL's installed location for `poppler-data`. This happens to be incorrect anyway for the conda-forge packaging. With this OFF then it will rely on the value set at compile time and updated by conda when installing the package.

Another side effect of this was that a `DllMain` function was being created (which didn't make sense for the static lib) and this was preventing other shared libraries like `gdal` linking to the static library. 

See https://gitlab.freedesktop.org/poppler/poppler/blob/master/poppler/GlobalParams.cc#L101
