### PR TITLE
Fix location of data files on Windows

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -13,7 +13,6 @@ cmake -G "Ninja" ^
       -D ENABLE_UNSTABLE_API_ABI_HEADERS=True ^
       -D ENABLE_LIBCURL=True ^
       -D ENABLE_LIBOPENJPEG=openjpeg2 ^
-      -D ENABLE_RELOCATABLE=OFF ^
        %SRC_DIR%
 if errorlevel 1 exit 1	   
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,7 @@ source:
     - includesystembeforejpeg.patch  # [win]
     - vs2015-no-for-loop-constexpr.win.patch  # [win]
     - strncasecmp_fix.patch  # [win]
+    - windows-data.patch  # [win]
 
 build:
   number: 0
@@ -59,6 +60,7 @@ requirements:
 
 test:
   commands:
+    - pdfinfo -listenc
     - pdfunite --help
     - pdftocairo --help
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
     - windows-data.patch  # [win]
 
 build:
-  number: 0
+  number: 1
   detect_binary_files_with_prefix: true
   skip: true  # [(unix and (cxx_compiler == 'toolchain_cxx')) or (win and py27)]
 

--- a/recipe/windows-data.patch
+++ b/recipe/windows-data.patch
@@ -1,0 +1,15 @@
+diff --git a/poppler/GlobalParams.cc b/poppler/GlobalParams.cc
+index 5d1ef22..86e89bb 100644
+--- a/poppler/GlobalParams.cc
++++ b/poppler/GlobalParams.cc
+@@ -140,6 +140,10 @@ static const char *get_poppler_datadir(void)
+         if (stricmp((const char *)(p + 1), "bin") == 0)
+             *p = '\0';
+     }
++    p = _mbsrchr((unsigned char *)retval, '\\');
++    if (p) {
++        *p = '\0';
++    }
+     strcat(retval, "\\share\\poppler");
+ 
+     beenhere = 1;


### PR DESCRIPTION
We can take advantage of existing "relocation" support in poppler/GlobalParams.cc -- it's not convenient to use Conda's prefix rewriting because the prefix path has to be in "mixed" form (`C:/foo/bar`), I think, and we'd need to add some custom code to deal with that. On the other hand, we can essentially use the relocation code, except for a patch to find the data files in $PREFIX/share/poppler while the DLL lives in $PREFIX/Library/bin/poppler.dll. This, in turn, happens because the poppler-data package is noarch and so has a common file layout on Unixes and Windows.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Closes #76.

<!--
Please add any other relevant info below:
-->
