### PR TITLE
Attempt to fix TIFF I/O on Windows

### DIFF
--- a/recipe/disable-libtiff-win32-io.patch
+++ b/recipe/disable-libtiff-win32-io.patch
@@ -1,20 +1,23 @@
-diff -Naur poppler-21.02.0_orig/goo/TiffWriter.cc poppler-21.02.0/goo/TiffWriter.cc
---- poppler-21.02.0_orig/goo/TiffWriter.cc	2021-02-01 22:23:11.000000000 +0100
-+++ poppler-21.02.0/goo/TiffWriter.cc	2021-02-03 15:20:15.820428600 +0100
-@@ -162,12 +162,12 @@
+diff --git a/goo/TiffWriter.cc b/goo/TiffWriter.cc
+index 98cbea5..65e99a1 100644
+--- a/goo/TiffWriter.cc
++++ b/goo/TiffWriter.cc
+@@ -164,12 +164,12 @@ bool TiffWriter::init(FILE *openedFile, int width, int height, int hDPI, int vDP
          return false;
      }
  
 -#    ifdef _WIN32
-+//#    ifdef _WIN32
-     // Convert C Library handle to Win32 Handle
+-    // Convert C Library handle to Win32 Handle
 -    priv->f = TIFFFdOpen(_get_osfhandle(fileno(openedFile)), "-", "w");
 -#    else
-+//    priv->f = TIFFFdOpen(_get_osfhandle(fileno(openedFile)), "-", "w");
-+//#    else
-     priv->f = TIFFFdOpen(fileno(openedFile), "-", "w");
+-    priv->f = TIFFFdOpen(fileno(openedFile), "-", "w");
 -#    endif
-+//#    endif
++    // conda-forge: our libtiff uses Unix FDs even on Windows. But
++    // we must be careful to dup() the FD, because otherwise we will
++    // cause crashes from closing a file handle twice on Windows:
++    // once in TIFFClose(), and once in the caller, which expects to
++    // have to fclose(openedFile) itself.
++    priv->f = TIFFFdOpen(dup(fileno(openedFile)), "-", "w");
  
      if (!priv->f) {
          return false;

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
     - disable-libtiff-win32-io.patch  # [win]
 
 build:
-  number: 1
+  number: 2
   detect_binary_files_with_prefix: true
 
 requirements:


### PR DESCRIPTION
From looking into #111, it seems that we were crashing when the TiffWriter was used because the TIFF file handle was being closed twice, which is a no-no on Windows. The TIFF writer needs to call TIFFClose() to clean up resources, and that automatically closes the TIFF file handle, but the semantics of the poppler "writer" classes are such that it's the caller's responsibility to close their file handles. Fortunately, it looks like things work if we dup() the file handle.

Closes #111.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
