### PR TITLE
Replace qt with qt-main

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -9,7 +9,7 @@ c_compiler_version:
 cairo:
 - '1.16'
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -69,12 +69,8 @@ pin_run_as_build:
     max_pin: x
   openjpeg:
     max_pin: x.x
-  qt:
-    max_pin: x.x
   zlib:
     max_pin: x.x
-qt:
-- '5.12'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -73,12 +73,8 @@ pin_run_as_build:
     max_pin: x
   openjpeg:
     max_pin: x.x
-  qt:
-    max_pin: x.x
   zlib:
     max_pin: x.x
-qt:
-- '5.12'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -69,12 +69,8 @@ pin_run_as_build:
     max_pin: x
   openjpeg:
     max_pin: x.x
-  qt:
-    max_pin: x.x
   zlib:
     max_pin: x.x
-qt:
-- '5.12'
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -69,8 +69,12 @@ pin_run_as_build:
     max_pin: x
   openjpeg:
     max_pin: x.x
+  qt:
+    max_pin: x.x
   zlib:
     max_pin: x.x
+qt:
+- '5.12'
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -7,7 +7,7 @@ boost_cpp:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 cairo:
 - '1.16'
 channel_sources:
@@ -19,7 +19,7 @@ curl:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 fontconfig:
 - '2.13'
 freetype:
@@ -69,12 +69,8 @@ pin_run_as_build:
     max_pin: x
   openjpeg:
     max_pin: x.x
-  qt:
-    max_pin: x.x
   zlib:
     max_pin: x.x
-qt:
-- '5.12'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -7,7 +7,7 @@ boost_cpp:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 cairo:
 - '1.16'
 channel_sources:
@@ -19,7 +19,7 @@ curl:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 fontconfig:
 - '2.13'
 freetype:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -57,12 +57,8 @@ pin_run_as_build:
     max_pin: x
   openjpeg:
     max_pin: x.x
-  qt:
-    max_pin: x.x
   zlib:
     max_pin: x.x
-qt:
-- '5.12'
 target_platform:
 - win-64
 zlib:

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,5 +1,7 @@
 build_platform:
   osx_arm64: osx_64
+os_version:
+  linux_64: cos7
 conda_forge_output_validation: true
 provider: {linux_aarch64: azure, linux_ppc64le: azure, win: azure}
 test_on_native_only: true

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -77,7 +77,6 @@ requirements:
     - nss  # [not win]
     - openjpeg
     - qt-main  # [not ppc64le]
-    - qt  # [ppc64le]
     - zlib
 
 outputs:
@@ -206,7 +205,6 @@ outputs:
         - nss  # [not win]
         - openjpeg
         - qt-main  # [not ppc64le]
-        - qt  # [ppc64le]
         - zlib
         - {{ pin_subpackage('poppler', exact=True) }}
       run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -76,7 +76,8 @@ requirements:
     - libtiff
     - nss  # [not win]
     - openjpeg
-    - qt-main  # [not (ppc64le or arm64)]
+    - qt-main  # [not (ppc64le or arm64 or aarch64)]
+    - qt  # [aarch64]
     - zlib
 
 outputs:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,11 +19,12 @@ source:
     - includesystembeforejpeg.patch  # [win]
 
 build:
-  number: 0
+  number: 1
   detect_binary_files_with_prefix: true
 
 requirements:
   build:
+    - sysroot_linux-64 2.17  # [linux64]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     # Need these CDTs for Qt on Linux. Please keep them alphabetized!
@@ -75,7 +76,7 @@ requirements:
     - libtiff
     - nss  # [not win]
     - openjpeg
-    - qt  # [not (ppc64le or arm64)]
+    - qt-main  # [not (ppc64le or arm64)]
     - zlib
 
 outputs:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -76,7 +76,7 @@ requirements:
     - libtiff
     - nss  # [not win]
     - openjpeg
-    - qt-main  # [not ppc64le]
+    - qt-main  # [not (ppc64le or arm64)]
     - zlib
 
 outputs:
@@ -204,7 +204,7 @@ outputs:
         - libtiff
         - nss  # [not win]
         - openjpeg
-        - qt-main  # [not ppc64le]
+        - qt-main  # [not (ppc64le or arm64)]
         - zlib
         - {{ pin_subpackage('poppler', exact=True) }}
       run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -76,8 +76,8 @@ requirements:
     - libtiff
     - nss  # [not win]
     - openjpeg
-    - qt-main  # [not (ppc64le or arm64 or aarch64)]
-    - qt  # [aarch64]
+    - qt-main  # [not ppc64le]
+    - qt  # [ppc64le]
     - zlib
 
 outputs:
@@ -205,7 +205,8 @@ outputs:
         - libtiff
         - nss  # [not win]
         - openjpeg
-        - qt
+        - qt-main  # [not ppc64le]
+        - qt  # [ppc64le]
         - zlib
         - {{ pin_subpackage('poppler', exact=True) }}
       run:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
This PR updates the recipe to depend on the new `qt-main` package instead of the old full `qt`.
<!--
Please add any other relevant info below:
-->
