### PR TITLE
add ignore run_exports for qt-main

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
     - includesystembeforejpeg.patch  # [win]
 
 build:
-  number: 1
+  number: 2
   detect_binary_files_with_prefix: true
   # We need to have `qt-main` as a host dep for the `poppler` package to satisfy
   # the build system, so we need to prevent it from becoming a runtime dep.
@@ -94,6 +94,7 @@ outputs:
     build:
       ignore_run_exports_from:
         - libboost-devel
+        - qt-main
       run_exports:
         - {{ pin_subpackage('poppler', max_pin='x.x') }}
     requirements:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Hopefully this addresses #165 by adding qt-main to ignore run_exports
@conda-forge-admin please rerender